### PR TITLE
fix: expose data file and remove unnecessary methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
-yarn.lock
+package-lock.json
+.nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - '10'
   - '8'
   - '6'
+after_script:
+  - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/index.js
+++ b/index.js
@@ -3,12 +3,8 @@
 const uniqueRandomArray = require('unique-random-array');
 const collection = require('./gtlds.json');
 
-const get = needle => collection.find(({gTLD}) => gTLD === needle);
 const names = collection.map(({gTLD}) => gTLD);
-const isValid = needle => names.includes(needle);
 
 module.exports.all = collection;
-module.exports.get = get;
-module.exports.isValid = isValid;
 module.exports.names = names;
 module.exports.random = uniqueRandomArray(collection);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gtlds",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "A list of all gGTLD names from the ICANN registry.",
 	"license": "MIT",
 	"repository": "chrisvogt/gtlds",

--- a/package.json
+++ b/package.json
@@ -14,26 +14,37 @@
 	},
 	"scripts": {
 		"sync": "node ./sync",
-		"test": "xo && ava --verbose"
+		"test": "xo && nyc ava --verbose"
 	},
 	"files": [
+		"gtlds.json",
 		"index.js",
 		"sync.js"
 	],
 	"keywords": [
-		"tld",
+		"TLD",
 		"website",
-    "ICANN",
-    "domain",
-    "gtld"
+		"ICANN",
+		"domain",
+		"domains",
+		"gTLD",
+		"gTLDs"
 	],
 	"dependencies": {
 		"unique-random-array": "^1.0.1"
 	},
 	"devDependencies": {
 		"ava": "^0.25.0",
+		"codecov": "^3.1.0",
 		"got": "^9.2.2",
+		"nyc": "^13.0.1",
 		"xo": "^0.23.0"
+  },
+	"nyc": {
+		"reporter": [
+			"lcov",
+			"text"
+		]
 	},
 	"xo": {
 		"space": true

--- a/readme.md
+++ b/readme.md
@@ -19,18 +19,6 @@ $ npm install gtlds
 ```js
 const gtlds = require('gtlds');
 
-gtlds.get('apple');
-/*
-{
-  "contractTerminated":false,
-  "gTLD":"apple",
-  "registryOperator":"Apple Inc."
-}
-*/
-
-gtlds.isValid('apple');
-/* TRUE */
-
 gtlds.random();
 /*
 {
@@ -55,20 +43,6 @@ gTLDs in alphabetical order.
 Type: `Array`
 
 gTLD names in alphabetical order.
-
-### .get(`gTLD` _string_)
-
-Type: `Function`
-
-Get data for a specific gTLD.
-
-### .isValid(`gTLD` _string_)
-
-Type: `Function`
-
-Validate a gTLD name.
-
-_NOTE: Returns `true` for terminated gTLDs._
 
 ### .random()
 

--- a/test.js
+++ b/test.js
@@ -17,19 +17,6 @@ test('it returns an array of names from the collection', t => {
   t.deepEqual(gtlds.names, allNames);
 });
 
-test('it gets the expected gTLD object from the collection', t => {
-  const needle = 'google';
-  const result = gtlds.get(needle);
-  const target = gtlds.all.find(({gTLD}) => gTLD === needle);
-  t.deepEqual(result, target);
-  t.deepEqual(Object.keys(result), expectedKeys);
-});
-
-test('it returns false for invalid gTLDs', t => {
-  const invalidName = '#@*$invalidNam3';
-  t.is(gtlds.isValid(invalidName), false);
-});
-
 test('it gets a random object from the collection', t => {
   const gTLD = gtlds.random();
   t.truthy(gTLD);


### PR DESCRIPTION
This PR exposes the _gtlds.json_ file, adds `nyc` and `codecov` for code coverage reporting, and removes the `get()` and `isValid()` methods.